### PR TITLE
Fix Compatible with "OS Version" of iOS 11 and later, it is "OS Version:      iOS 11.1 (15B93)"

### DIFF
--- a/symbolicate/symbolicate.py
+++ b/symbolicate/symbolicate.py
@@ -93,7 +93,7 @@ def _match_os_version_re():
     """
     匹配系统版本
     """
-    return r'^OS\sVersion:\s*iPhone\sOS\s(.+)\s*$'
+    return r'^OS\sVersion:\s*i[^0-9]+(.+)\s*$'
 
 def _match_stack_item_re():
     """


### PR DESCRIPTION
example for iOS 11
OS Version:      iOS 11.1 (15B93)
example for iOS 10
OS Version:      iPhone OS 10.3.3 (14G60)